### PR TITLE
feature-968594

### DIFF
--- a/SQL/10_out_ProjectUserSecurity.sql
+++ b/SQL/10_out_ProjectUserSecurity.sql
@@ -9,7 +9,7 @@ select
 from stg_csv_ProjectUserSecurity_merge t
 where Deleted = false
 
-/*union all
+union all
 
 select
 	${TRANSFORM_ID['TRANSFORM_ID']} as _sys_transform_id,
@@ -17,7 +17,7 @@ select
 	 GoodData_Attr(UserId||'#'||-1)  as "ProjectUserSecurityId"
 	,GoodData_Attr(UserId)  as "UserId"
 	,GoodData_Attr(-1) as "ProjectId"
-from stg_csv_User_merge u;*/
+from stg_csv_User_merge u;
 ;
 INSERT INTO _sys_transform_id (id,entity,ts_start,ts_end) VALUES (${TRANSFORM_ID['TRANSFORM_ID']},'dm_ProjectUserSecurity',null,now());
 select analyze_statistics('out_ProjectUserSecurity')


### PR DESCRIPTION
FENXT: GoodData - Budgets and actuals do not display at the same time in FENXT Analysis for non-Supervisor users
Co-Authored-By: Ben Cook <blackbaud-bencook@users.noreply.github.com>
Co-Authored-By: blackbaud-melissabethancourt <blackbaud-melissabethancourt@users.noreply.github.com>

*Description of changes:*  Uncommented code allow all users from seeing transactions that have no associated project.

*VSTS work item:* https://blackbaud.visualstudio.com/Products/FENext%20-%20Integrators/_workitems/edit/968594 

*Items to complete before pull request is merged:*
[X] Reviewed and approved by Blackbaud
[X] VSTS work item linked above
[ ] Change deployed to CDEV *(`develop` branch only)* or ATE *(`master` branch only)*
[ ] Change tested in CDEV or ATE
[ ] Change deployed to PROD *(`master` branch only)*
